### PR TITLE
Fix webfonts over https

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <html>
 <head>
   <title>Google Web Components Kit</title>
-  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto|Source+Code+Pro:400,600">
+  <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto|Source+Code+Pro:400,600">
   <link rel="stylesheet" href="css/app.css">
   <script src="bower_components/platform/platform.js"></script>
   <link rel="import" href="bower_components/polymer/polymer.html">


### PR DESCRIPTION
Change Google Webfont to load via a protocol-relative URL so it still works over HTTPS. Note that there are still some other HTTPS breakages not fixed here. 
